### PR TITLE
Upgrade OpenAI to 4.104.0 and fix TypeScript errors

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,43 +5,43 @@ on:
     branches:
       - main
     paths:
-      - 'package.json'
+      - "package.json"
   workflow_dispatch:
     # This allows manual triggering of the workflow
 
 jobs:
   publish:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
           bun-version: latest
-      
+
       - name: Install dependencies
         run: bun install
-      
+
       - name: Run tests
         run: bun test
         env:
           OPENAI_API_KEY: dummy-key-for-ci
-      
+
       - name: Setup npm authentication
         run: |
           # Try direct login first
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}" > ~/.npmrc
-          
+
           # Let's try solving it specifically from Bun's perspective
           bunx npm config set //registry.npmjs.org/:_authToken "${{ secrets.NPM_AUTH_TOKEN }}"
-      
+
       - name: Publish package
         run: |
           # Check if we're authenticated
           npm whoami || echo "Authentication still not working"
-          
+
           # Try publishing with npm directly if bun has issues
           npm publish --access public

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,7 @@
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Build & Test Commands
+
 - Install dependencies: `bun install`
 - Run the project: `bun run index.ts`
 - Run all tests: `bun test`
@@ -15,6 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 When the user corrects a suggested command, record it here for later use.
 
 ## Code Style Guidelines
+
 - **Types**: Use TypeScript with strict mode enabled
 - **Imports**: Use ES modules (`import` syntax)
 - **Error Handling**: Create custom error classes that extend Error
@@ -25,6 +27,7 @@ When the user corrects a suggested command, record it here for later use.
 - **Format**: Keep code clean and consistent with clear naming
 
 ## Deployment
+
 - Package is auto-published via GitHub Actions when:
   1. Changes are pushed to `main` branch
   2. `package.json` was modified

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ import { OpenAIBot, ClaudeBot, PromptFunction } from "colloquy_chatbot";
 
 // Create a basic OpenAI chatbot
 const openaiBot = new OpenAIBot({
-  instructions: "You are a helpful assistant."
+  instructions: "You are a helpful assistant.",
 });
 
 // Or use Claude
 const claudeBot = new ClaudeBot({
-  instructions: "You are a helpful assistant."
+  instructions: "You are a helpful assistant.",
 });
 
 // Send a message and get a response
@@ -43,12 +43,14 @@ const weatherBot = new OpenAIBot({
   instructions: "You can check the weather.",
   functions: [
     new PromptFunction(getWeather, {
-      description: "Get the current weather for a location"
-    })
-  ]
+      description: "Get the current weather for a location",
+    }),
+  ],
 });
 
-const weatherResponse = await weatherBot.prompt("What's the weather like in Tokyo?");
+const weatherResponse = await weatherBot.prompt(
+  "What's the weather like in Tokyo?",
+);
 console.log(weatherResponse);
 ```
 
@@ -62,7 +64,7 @@ The main chatbot implementation that uses OpenAI's API:
 import { OpenAIBot } from "colloquy_chatbot";
 
 const bot = new OpenAIBot({
-  instructions: "You are a helpful assistant." // Optional system message
+  instructions: "You are a helpful assistant.", // Optional system message
 });
 
 const response = await bot.prompt("Hello!");
@@ -80,7 +82,7 @@ The chatbot implementation that uses Anthropic's Claude API:
 import { ClaudeBot } from "colloquy_chatbot";
 
 const bot = new ClaudeBot({
-  instructions: "You are a helpful assistant." // Optional system message
+  instructions: "You are a helpful assistant.", // Optional system message
 });
 
 const response = await bot.prompt("Hello!");
@@ -142,10 +144,10 @@ const bot = new OpenAIBot({
       description: "Calculate the area of a rectangle",
       parameters: {
         length: { description: "The length of the rectangle" },
-        width: { description: "The width of the rectangle" }
-      }
-    })
-  ]
+        width: { description: "The width of the rectangle" },
+      },
+    }),
+  ],
 });
 
 // The AI can now use the function when appropriate
@@ -170,10 +172,10 @@ const bot = new ClaudeBot({
       description: "Calculate the area of a rectangle",
       parameters: {
         length: { description: "The length of the rectangle" },
-        width: { description: "The width of the rectangle" }
-      }
-    })
-  ]
+        width: { description: "The width of the rectangle" },
+      },
+    }),
+  ],
 });
 
 // Claude can now use the function when appropriate
@@ -182,9 +184,10 @@ console.log(response);
 ```
 
 It can infer a lot from the function definition itself:
-* It can determine the name from the name of the function
+
+- It can determine the name from the name of the function
   - It understands both `() => "foo"` and `function test() { return "foo" }`, but only the latter has a name attached
-* Default parameters are used to infer the type when they are specified
+- Default parameters are used to infer the type when they are specified
   - Typescript annotations are stripped at runtime, but default parameters are always there
 
 These inferences are there to make your life easier, but you can always override everything but parameter names like this:
@@ -201,9 +204,9 @@ new PromptFunction(calculateArea, {
     width: {
       type: "number",
       description: "The width of the rectangle",
-    }
-  }
-})
+    },
+  },
+});
 ```
 
 Positional arguments get translated into an object before being sent to OpenAI, so feel free to use them in your functions. The goal is to allow you to define functions in a way that is intuitive, while still translating into a form supported by the API.

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
         "@anthropic-ai/sdk": "^0.39.0",
         "escodegen": "^2.1.0",
         "esprima": "^4.0.1",
-        "openai": "^4.95.0",
+        "openai": "4.104.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -104,7 +104,7 @@
 
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
-    "openai": ["openai@4.95.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" }, "peerDependencies": { "ws": "^8.18.0", "zod": "^3.23.8" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-tWHLTA+/HHyWlP8qg0mQLDSpI2NQLhk6zHLJL8yb59qn2pEI8rbEiAGSDPViLvi3BRDoQZIX5scaJ3xYGr2nhw=="],
+    "openai": ["openai@4.104.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" }, "peerDependencies": { "ws": "^8.18.0", "zod": "^3.23.8" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colloquy_chatbot",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "main": "./src/colloquy.ts",
   "type": "module",
   "devDependencies": {
@@ -15,6 +15,6 @@
     "@anthropic-ai/sdk": "^0.39.0",
     "escodegen": "^2.1.0",
     "esprima": "^4.0.1",
-    "openai": "^4.95.0"
+    "openai": "4.104.0"
   }
 }

--- a/src/chat_bot.ts
+++ b/src/chat_bot.ts
@@ -1,27 +1,31 @@
 import type { Message, MessageFactory, TextMessage } from "./message";
 
 export abstract class ChatBot<M extends Message> {
-  history: M[]
+  history: M[];
   instructions: string | undefined;
   debug: boolean;
 
-  constructor({ instructions, history = [], debug = false }: { instructions?: string, history?: M[], debug?: boolean } = {}) {
-    this.history = history
-    this.instructions = instructions
-    this.debug = debug
+  constructor({
+    instructions,
+    history = [],
+    debug = false,
+  }: { instructions?: string; history?: M[]; debug?: boolean } = {}) {
+    this.history = history;
+    this.instructions = instructions;
+    this.debug = debug;
   }
 
-  abstract get message_factory(): MessageFactory<M>
+  abstract get message_factory(): MessageFactory<M>;
 
   async prompt(content: string) {
-    const message = this.message_factory.user(content)
+    const message = this.message_factory.user(content);
 
-    this.history.push(message)
-    const response = await this.send_prompt()
-    this.history.push(response)
+    this.history.push(message);
+    const response = await this.send_prompt();
+    this.history.push(response);
 
-    return response.text
+    return response.text;
   }
 
-  abstract send_prompt(): Promise<TextMessage & M>
+  abstract send_prompt(): Promise<TextMessage & M>;
 }

--- a/src/claude/message.ts
+++ b/src/claude/message.ts
@@ -1,31 +1,37 @@
-import type { MessageParam, ToolUseBlock } from "@anthropic-ai/sdk/resources/index.mjs"
-import * as base from "../message"
-import type { PromptFunction } from "../function"
+import type {
+  MessageParam,
+  ToolUseBlock,
+} from "@anthropic-ai/sdk/resources/index.mjs";
+import * as base from "../message";
+import type { PromptFunction } from "../function";
 
-type Role = "user" | "assistant"
+type Role = "user" | "assistant";
 
-export type RM = base.RoleMessage<Role, MessageParam>
-export type IM = base.InputMessage<MessageParam>
+export type RM = base.RoleMessage<Role, MessageParam>;
+export type IM = base.InputMessage<MessageParam>;
 
 export class ClaudeMessageFactory implements base.MessageFactory<IM> {
   user(text: string): RM {
-    return new base.RoleMessage("user", text)
+    return new base.RoleMessage("user", text);
   }
 
   deserialize(content: any): RM {
     if (content.type === "text") {
-      return new base.RoleMessage("assistant", content.text)
+      return new base.RoleMessage("assistant", content.text);
     } else {
       throw new Error(`Unhandled output type ${content.type}`);
     }
   }
 }
 
-export class FunctionCallMessage<T> extends base.FunctionCallMessage<T> implements base.InputMessage<MessageParam> {
-  content: ToolUseBlock
+export class FunctionCallMessage<T>
+  extends base.FunctionCallMessage<T>
+  implements base.InputMessage<MessageParam>
+{
+  content: ToolUseBlock;
   constructor(fn: PromptFunction<T>, content: ToolUseBlock, result?: string) {
-    super(fn, result)
-    this.content = content
+    super(fn, result);
+    this.content = content;
   }
 
   async input(): Promise<MessageParam[]> {
@@ -35,17 +41,19 @@ export class FunctionCallMessage<T> extends base.FunctionCallMessage<T> implemen
         role: "assistant",
       },
       {
-        content: [{
-          type: "tool_result",
-          tool_use_id: this.content.id,
-          content: await this.invoke_fn(),
-        }],
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: this.content.id,
+            content: await this.invoke_fn(),
+          },
+        ],
         role: "user",
-      }
-    ]
+      },
+    ];
   }
 
   get arguments(): Record<string, any> {
-    return this.content.input as Record<string, any>
+    return this.content.input as Record<string, any>;
   }
 }

--- a/src/colloquy.ts
+++ b/src/colloquy.ts
@@ -1,5 +1,5 @@
-export type { ChatBot } from "./chat_bot"
-export { EchoBot } from "./echo_bot"
-export { OpenAIBot } from "./openai_bot"
-export { ClaudeBot } from "./claude_bot"
-export { PromptFunction, UnnamedFunctionError } from "./function"
+export type { ChatBot } from "./chat_bot";
+export { EchoBot } from "./echo_bot";
+export { OpenAIBot } from "./openai_bot";
+export { ClaudeBot } from "./claude_bot";
+export { PromptFunction, UnnamedFunctionError } from "./function";

--- a/src/echo_bot.ts
+++ b/src/echo_bot.ts
@@ -1,23 +1,23 @@
-import { ChatBot } from "./chat_bot"
-import { type MessageFactory, SimpleMessage } from "./message"
+import { ChatBot } from "./chat_bot";
+import { type MessageFactory, SimpleMessage } from "./message";
 
 class EchoMessageFactory implements MessageFactory<SimpleMessage> {
   user(text: string) {
-    return new SimpleMessage(text)
+    return new SimpleMessage(text);
   }
 
   deserialize(text: any) {
-    return this.user(text)
+    return this.user(text);
   }
 }
 
 export class EchoBot extends ChatBot<SimpleMessage> {
   get message_factory() {
-    return new EchoMessageFactory()
+    return new EchoMessageFactory();
   }
 
   async send_prompt() {
-    const message = this.history.at(-1)
-    return new SimpleMessage(message!.text)
+    const message = this.history.at(-1);
+    return new SimpleMessage(message!.text);
   }
 }

--- a/src/function.ts
+++ b/src/function.ts
@@ -1,56 +1,68 @@
-import { parseScript, type Program } from "esprima"
-import type { BaseNode, FunctionDeclaration, Pattern, ExpressionStatement, ArrowFunctionExpression, Identifier } from "estree"
-import { generate } from "escodegen"
+import { parseScript, type Program } from "esprima";
+import type {
+  BaseNode,
+  FunctionDeclaration,
+  Pattern,
+  ExpressionStatement,
+  ArrowFunctionExpression,
+  Identifier,
+} from "estree";
+import { generate } from "escodegen";
 
 export class UnnamedFunctionError extends Error {}
 
 export class PromptFunctionRepository {
-  functions: { [k: string]: PromptFunction<any> }
+  functions: { [k: string]: PromptFunction<any> };
   constructor(functions: PromptFunction<any>[]) {
-    this.functions = Object.fromEntries(functions.map((f) => [f.name, f]))
+    this.functions = Object.fromEntries(functions.map((f) => [f.name, f]));
   }
 
   lookup<T>(name: string): PromptFunction<T> {
-    return this.functions[name]
+    return this.functions[name];
   }
 
   get array() {
-    return Object.values(this.functions)
+    return Object.values(this.functions);
   }
 }
 
 export type Parameter = {
-  type: string
-  description?: string
-  properties?: Parameters }
-type Parameters = { [name: string]: Parameter }
+  type: string;
+  description?: string;
+  properties?: Parameters;
+};
+type Parameters = { [name: string]: Parameter };
 
 type ParameterOverlay = {
-  type?: string
-  description?: string
-  properties?: ParametersOverlay
-}
-type ParametersOverlay = { [name: string]: ParameterOverlay }
+  type?: string;
+  description?: string;
+  properties?: ParametersOverlay;
+};
+type ParametersOverlay = { [name: string]: ParameterOverlay };
 
 export class PromptFunction<Return> {
-  fn: (...args: any[]) => Return
-  name: string
-  description: string | undefined
-  parameters: ParametersOverlay
+  fn: (...args: any[]) => Return;
+  name: string;
+  description: string | undefined;
+  parameters: ParametersOverlay;
   constructor(
     fn: (...args: any[]) => Return,
-    { name, description, parameters = {} }: {
-      name?: string
-      description?: string
-      parameters?: ParametersOverlay
-    } = {}
+    {
+      name,
+      description,
+      parameters = {},
+    }: {
+      name?: string;
+      description?: string;
+      parameters?: ParametersOverlay;
+    } = {},
   ) {
-    if (!name && fn.name == "") throw new UnnamedFunctionError()
+    if (!name && fn.name == "") throw new UnnamedFunctionError();
 
-    this.fn = fn
-    this.name = name || fn.name
-    this.description = description
-    this.parameters = parameters
+    this.fn = fn;
+    this.name = name || fn.name;
+    this.description = description;
+    this.parameters = parameters;
   }
 
   get object_spec() {
@@ -58,142 +70,151 @@ export class PromptFunction<Return> {
       type: "object",
       properties: this.properties,
       required: this.parameter_names,
-    }
+    };
   }
 
   get properties() {
-    return Object.fromEntries(parameters_for(this.fn, this.parameters))
+    return Object.fromEntries(parameters_for(this.fn, this.parameters));
   }
 
   get parameter_names() {
     return parameters_for(this.fn, this.parameters).map(
-      ([name, _param]) => name
-    )
+      ([name, _param]) => name,
+    );
   }
 
   async invoke(params: { [name: string]: any }): Promise<string> {
-    const result = await this.fn(...this.parameter_ordering(params))
+    const result = await this.fn(...this.parameter_ordering(params));
 
-    if (typeof result === "string") return result
+    if (typeof result === "string") return result;
 
-    return JSON.stringify(result)
+    return JSON.stringify(result);
   }
 
   private parameter_ordering(params: { [name: string]: any }) {
-    return this.parameter_names.map((name) => params[name])
+    return this.parameter_names.map((name) => params[name]);
   }
 }
 
-export function parameters_for(fn: (...args: any[]) => any, overlay: ParametersOverlay = {}) {
-  const ast = parseScript(fn.toString())
+export function parameters_for(
+  fn: (...args: any[]) => any,
+  overlay: ParametersOverlay = {},
+) {
+  const ast = parseScript(fn.toString());
 
-  let fn_ast = (
-    find_node(ast, "FunctionDeclaration") || find_node(ast, "ArrowFunctionExpression")
-  ) as FunctionDeclaration | ArrowFunctionExpression | undefined
+  let fn_ast = (find_node(ast, "FunctionDeclaration") ||
+    find_node(ast, "ArrowFunctionExpression")) as
+    | FunctionDeclaration
+    | ArrowFunctionExpression
+    | undefined;
 
-  return extract_params(fn_ast?.params || []).map(
-    (param) => augment_param(param, overlay),
-  )
+  return extract_params(fn_ast?.params || []).map((param) =>
+    augment_param(param, overlay),
+  );
 }
 
 function find_node(ast: BaseNode, type: string): BaseNode | undefined {
-  if (ast.type == type) return ast
+  if (ast.type == type) return ast;
 
   if (ast.type == "Program") {
-    const program = ast as Program
+    const program = ast as Program;
     for (const node of program.body) {
-      const search = find_node(node, type)
-      if (search) return search
+      const search = find_node(node, type);
+      if (search) return search;
     }
   }
 
   if (ast.type == "ExpressionStatement") {
-    const expression = ast as ExpressionStatement
-    return find_node(expression.expression, type)
+    const expression = ast as ExpressionStatement;
+    return find_node(expression.expression, type);
   }
 
-  return undefined
+  return undefined;
 }
 
 function extract_params(ast: Pattern[]) {
   const params: {
-    name: string
-    def?: BaseNode
-  }[] = []
+    name: string;
+    def?: BaseNode;
+  }[] = [];
 
   for (const prm of ast) {
-    let name: string
-    let def: BaseNode | undefined
+    let name: string;
+    let def: BaseNode | undefined;
     if (prm.type == "Identifier") {
-      name = prm.name
+      name = prm.name;
     } else if (prm.type == "AssignmentPattern") {
-      name = (prm.left as Identifier).name
-      def = prm.right
+      name = (prm.left as Identifier).name;
+      def = prm.right;
     } else {
-      throw new Error(`Unexpected node type: ${prm.type}`)
+      throw new Error(`Unexpected node type: ${prm.type}`);
     }
 
     params.push({
       name,
       def,
-    })
+    });
   }
 
-  return params
+  return params;
 }
 
-function augment_param({ name, def }: { name: string, def?: BaseNode }, overlay: ParametersOverlay): [string, Parameter] {
-  return [name, parameter_for(def, overlay[name])]
+function augment_param(
+  { name, def }: { name: string; def?: BaseNode },
+  overlay: ParametersOverlay,
+): [string, Parameter] {
+  return [name, parameter_for(def, overlay[name])];
 }
 
 function parameter_for(def: BaseNode | undefined, overlay: ParameterOverlay) {
-  let type = "any"
+  let type = "any";
   let properties;
 
   if (def) {
     let result;
 
-    const generated = generate(def)
+    const generated = generate(def);
     try {
-      result = eval(`(${generated})`)
-    } catch(e) {
-      throw new Error(`Problem evaluating \`(${generated})\`: ${e}`)
+      result = eval(`(${generated})`);
+    } catch (e) {
+      throw new Error(`Problem evaluating \`(${generated})\`: ${e}`);
     }
 
-    type = typeof result
+    type = typeof result;
 
     if (!result) {
-      type = "null"
+      type = "null";
     } else if (result && typeof result == "object") {
       return {
         type,
         ...overlay,
         properties: object_properties(result, overlay),
-      }
+      };
     }
   }
 
-  return { type, properties, ...overlay } as Parameter
+  return { type, properties, ...overlay } as Parameter;
 }
 
-function object_properties(value: { [name: string]: any }, overlay: ParameterOverlay): Parameters {
+function object_properties(
+  value: { [name: string]: any },
+  overlay: ParameterOverlay,
+): Parameters {
   return Object.fromEntries(
     Object.entries(value).map(([name, value]) => {
-      const sub_overlay = (overlay?.properties && overlay.properties[name]) || {}
+      const sub_overlay =
+        (overlay?.properties && overlay.properties[name]) || {};
       let parameter: Parameter = {
         type: typeof value,
-      }
+      };
 
       if (value && typeof value === "object") {
-        parameter.properties = object_properties(value, sub_overlay)
+        parameter.properties = object_properties(value, sub_overlay);
       } else {
-        parameter = { ...parameter, ...sub_overlay } as Parameter
+        parameter = { ...parameter, ...sub_overlay } as Parameter;
       }
 
-      return [
-        name,
-        parameter,
-      ]
-    })
-  )
+      return [name, parameter];
+    }),
+  );
 }

--- a/src/message.ts
+++ b/src/message.ts
@@ -1,60 +1,63 @@
-import type { PromptFunction } from "./function"
+import type { PromptFunction } from "./function";
 
 export interface MessageFactory<M> {
-  user(text: string): M
-  deserialize(serialized: any): M
+  user(text: string): M;
+  deserialize(serialized: any): M;
 }
 
 export interface Message {}
 
 export interface TextMessage extends Message {
-  text: string
+  text: string;
 }
 
 export interface InputMessage<T> {
-  input(): Promise<T[]>
+  input(): Promise<T[]>;
 }
 
 export class SimpleMessage implements TextMessage {
-  text: string
+  text: string;
   constructor(text: string) {
-    this.text = text
+    this.text = text;
   }
 }
 
-export class RoleMessage<Role, Input> extends SimpleMessage implements InputMessage<Input> {
-  role: Role
+export class RoleMessage<Role, Input>
+  extends SimpleMessage
+  implements InputMessage<Input>
+{
+  role: Role;
   constructor(role: Role, text: string) {
-    super(text)
-    this.role = role
+    super(text);
+    this.role = role;
   }
 
   async input(): Promise<Input[]> {
-    return [{ role: this.role, content: this.text }] as Input[]
+    return [{ role: this.role, content: this.text }] as Input[];
   }
 }
 
 export abstract class FunctionCallMessage<ReturnValue> {
-  fn: PromptFunction<ReturnValue>
-  result?: string
+  fn: PromptFunction<ReturnValue>;
+  result?: string;
   constructor(fn: PromptFunction<ReturnValue>, result?: string) {
-    this.fn = fn
-    this.result = result
+    this.fn = fn;
+    this.result = result;
   }
 
   async invoke_fn(): Promise<string> {
-    this.result ||= await this.fn.invoke(this.arguments)
-    return this.result
+    this.result ||= await this.fn.invoke(this.arguments);
+    return this.result;
   }
 
-  abstract get arguments(): Record<string, any>
+  abstract get arguments(): Record<string, any>;
 }
 
 export class FunctionResultMessage {
-  id: string
-  result: string
+  id: string;
+  result: string;
   constructor(id: string, result: string) {
-    this.id = id
-    this.result = result
+    this.id = id;
+    this.result = result;
   }
 }

--- a/src/openai/function.ts
+++ b/src/openai/function.ts
@@ -1,13 +1,13 @@
 import { type PromptFunction } from "../function";
-import type { FunctionTool } from "openai/resources/responses/responses.mjs"
+import type { FunctionTool } from "openai/resources/responses/responses.mjs";
 
 type StrictFunctionTool = FunctionTool & {
   parameters: {
-    properties: Record<string, unknown>,
-    additionalProperties: boolean,
-    required: string[],
-  }
-}
+    properties: Record<string, unknown>;
+    additionalProperties: boolean;
+    required: string[];
+  };
+};
 
 export function tool<T>(fn: PromptFunction<T>): StrictFunctionTool {
   const tool: StrictFunctionTool = {
@@ -18,8 +18,8 @@ export function tool<T>(fn: PromptFunction<T>): StrictFunctionTool {
       additionalProperties: false,
     },
     strict: true,
-  }
-  if (fn.description) tool.description = fn.description
+  };
+  if (fn.description) tool.description = fn.description;
 
-  return tool
+  return tool;
 }

--- a/src/openai/message.ts
+++ b/src/openai/message.ts
@@ -1,43 +1,52 @@
-import type { ResponseFunctionToolCall, ResponseInputItem, ResponseReasoningItem } from "openai/resources/responses/responses.mjs"
-import { PromptFunction, PromptFunctionRepository } from "../function"
-import * as base from "../message"
+import type {
+  ResponseFunctionToolCall,
+  ResponseInputItem,
+  ResponseReasoningItem,
+} from "openai/resources/responses/responses.mjs";
+import { PromptFunction, PromptFunctionRepository } from "../function";
+import * as base from "../message";
 
-type Role = "user" | "system" | "assistant"
-type IM = base.InputMessage<ResponseInputItem>
+type Role = "user" | "system" | "assistant";
+type IM = base.InputMessage<ResponseInputItem>;
 
 export class OpenAIMessageFactory implements base.MessageFactory<IM> {
-  functions: PromptFunctionRepository
+  functions: PromptFunctionRepository;
   constructor({ functions }: { functions: PromptFunctionRepository }) {
-    this.functions = functions
+    this.functions = functions;
   }
 
   user(text: string): base.RoleMessage<Role, ResponseInputItem> {
-    return new base.RoleMessage("user", text)
+    return new base.RoleMessage("user", text);
   }
 
   deserialize(json: any): IM {
-    if (json["role"])
-      return new base.RoleMessage(json["role"], json["text"])
+    if (json["role"]) return new base.RoleMessage(json["role"], json["text"]);
     else if (json["fn"])
       return new FunctionCallMessage(
         this.functions.lookup(json["fn"]["name"]),
         json["tool_call"],
         json["result"],
-      )
-    else
-      throw new Error(`Unexpected message: ${json}`)
+      );
+    else throw new Error(`Unexpected message: ${json}`);
   }
 }
 
-export class FunctionCallMessage<ReturnValue> extends base.FunctionCallMessage<ReturnValue> implements base.InputMessage<ResponseInputItem> {
-  tool_call: ResponseFunctionToolCall
-  constructor(fn: PromptFunction<ReturnValue>, tool_call: ResponseFunctionToolCall, result?: string) {
-    super(fn, result)
-    this.tool_call = tool_call
+export class FunctionCallMessage<ReturnValue>
+  extends base.FunctionCallMessage<ReturnValue>
+  implements base.InputMessage<ResponseInputItem>
+{
+  tool_call: ResponseFunctionToolCall;
+  constructor(
+    fn: PromptFunction<ReturnValue>,
+    tool_call: ResponseFunctionToolCall,
+    result?: string,
+  ) {
+    super(fn, result);
+    this.tool_call = tool_call;
   }
 
   get arguments() {
-    return JSON.parse(this.tool_call.arguments)
+    return JSON.parse(this.tool_call.arguments);
   }
 
   async input(): Promise<ResponseInputItem[]> {
@@ -46,25 +55,27 @@ export class FunctionCallMessage<ReturnValue> extends base.FunctionCallMessage<R
       {
         type: "function_call_output",
         call_id: this.tool_call.call_id,
-        output: await this.invoke_fn() || "",
-      }
-    ]
+        output: (await this.invoke_fn()) || "",
+      },
+    ];
   }
 }
 
 export class ReasoningMessage implements base.InputMessage<ResponseInputItem> {
-  id: string
-  summary: ResponseReasoningItem.Summary[]
+  id: string;
+  summary: ResponseReasoningItem.Summary[];
   constructor(id: string, summary: ResponseReasoningItem.Summary[]) {
-    this.id = id
-    this.summary = summary
+    this.id = id;
+    this.summary = summary;
   }
 
   async input(): Promise<ResponseInputItem[]> {
-    return [{
-      type: "reasoning",
-      id: this.id,
-      summary: this.summary,
-    }]
+    return [
+      {
+        type: "reasoning",
+        id: this.id,
+        summary: this.summary,
+      },
+    ];
   }
 }

--- a/src/openai_bot.ts
+++ b/src/openai_bot.ts
@@ -1,90 +1,109 @@
-import OpenAI from "openai"
+import OpenAI from "openai";
 
-import { ChatBot } from "./chat_bot"
-import { FunctionCallMessage, OpenAIMessageFactory, ReasoningMessage } from "./openai/message"
-import { PromptFunctionRepository, type PromptFunction } from "./function"
-import type { Response, ResponseCreateParams, ResponseFunctionToolCall, ResponseInputItem } from "openai/resources/responses/responses.mjs"
-import { tool } from "./openai/function"
-import { RoleMessage, type InputMessage } from "./message"
+import { ChatBot } from "./chat_bot";
+import {
+  FunctionCallMessage,
+  OpenAIMessageFactory,
+  ReasoningMessage,
+} from "./openai/message";
+import { PromptFunctionRepository, type PromptFunction } from "./function";
+import type {
+  Response,
+  ResponseCreateParams,
+  ResponseFunctionToolCall,
+  ResponseInputItem,
+} from "openai/resources/responses/responses.mjs";
+import { tool } from "./openai/function";
+import { RoleMessage, type InputMessage } from "./message";
 
-export type Role = "user" | "system" | "assistant"
-type RM = RoleMessage<Role, ResponseInputItem>
-type IM = InputMessage<ResponseInputItem>
+export type Role = "user" | "system" | "assistant";
+type RM = RoleMessage<Role, ResponseInputItem>;
+type IM = InputMessage<ResponseInputItem>;
 
 export class OpenAIBot extends ChatBot<IM> {
-  openai: OpenAI
-  functions: PromptFunctionRepository
-  service_tier?: ResponseCreateParams["service_tier"]
-  model: string
-  constructor({ model = "gpt-4o-mini", apiKey, service_tier = undefined, functions = [], ...args }: ConstructorParameters<typeof ChatBot<IM>>[0] & {
-    apiKey?: string
-    model?: string
-    functions?: PromptFunction<any>[]
-    service_tier?: ResponseCreateParams["service_tier"]
+  openai: OpenAI;
+  functions: PromptFunctionRepository;
+  service_tier?: ResponseCreateParams["service_tier"];
+  model: string;
+  constructor({
+    model = "gpt-4o-mini",
+    apiKey,
+    service_tier = undefined,
+    functions = [],
+    ...args
+  }: ConstructorParameters<typeof ChatBot<IM>>[0] & {
+    apiKey?: string;
+    model?: string;
+    functions?: PromptFunction<any>[];
+    service_tier?: ResponseCreateParams["service_tier"];
   } = {}) {
-    super(args)
-    this.openai = new OpenAI({ apiKey })
-    this.model = model
-    this.functions = new PromptFunctionRepository(functions)
-    this.service_tier = service_tier
+    super(args);
+    this.openai = new OpenAI({ apiKey });
+    this.model = model;
+    this.functions = new PromptFunctionRepository(functions);
+    this.service_tier = service_tier;
   }
 
   get message_factory() {
-    return new OpenAIMessageFactory({ functions: this.functions })
+    return new OpenAIMessageFactory({ functions: this.functions });
   }
 
   async send_prompt(): Promise<RM> {
-    if (this.debug) console.debug("request", await this.request())
-    const response = await this.openai.responses.create(await this.request()) as Response
-    if (this.debug) console.debug("response", response)
+    if (this.debug) console.debug("request", await this.request());
+    const response = (await this.openai.responses.create(
+      await this.request(),
+    )) as Response;
+    if (this.debug) console.debug("response", response);
 
     for (const output of response.output || []) {
       if (output.type === "function_call") {
-        await this.call_function(output)
+        await this.call_function(output);
       } else if (output.type === "reasoning") {
-        this.history.push(new ReasoningMessage(output.id, output.summary))
-      } else if (output.status === "completed") {
-        this.history.push(new RoleMessage("assistant", response.output_text))
+        this.history.push(new ReasoningMessage(output.id, output.summary));
+      } else if (output.type === "message" && output.status === "completed") {
+        this.history.push(new RoleMessage("assistant", response.output_text));
       } else {
-        throw new Error(`Unhandled output type ${JSON.stringify(output)}`)
+        throw new Error(`Unhandled output type ${JSON.stringify(output)}`);
       }
     }
 
     if (this.needs_reply(response)) {
-      return await this.send_prompt()
+      return await this.send_prompt();
     } else {
-      return this.history.pop() as RM
+      return this.history.pop() as RM;
     }
   }
 
   needs_reply(response: Response) {
-    return response.status != "completed"
-      || response.output.every(o => o.type != "message")
+    return (
+      response.status != "completed" ||
+      response.output.every((o) => o.type != "message")
+    );
   }
 
   private async call_function(tool_call: ResponseFunctionToolCall) {
-    const fn = this.functions.lookup(tool_call.name)
+    const fn = this.functions.lookup(tool_call.name);
 
-    const call = new FunctionCallMessage(fn, tool_call)
-    call.invoke_fn()
-    this.history.push(call)
+    const call = new FunctionCallMessage(fn, tool_call);
+    call.invoke_fn();
+    this.history.push(call);
   }
 
   private async request() {
-    const input = []
+    const input = [];
     for (const message of this.history) {
-      input.push(...await message.input())
+      input.push(...(await message.input()));
     }
 
     const req: ResponseCreateParams = {
       model: this.model,
       input,
       tools: this.functions.array.map((fn) => tool(fn)),
-    }
+    };
 
-    if (this.instructions) req.instructions = this.instructions
-    if (this.service_tier) req.service_tier = this.service_tier
+    if (this.instructions) req.instructions = this.instructions;
+    if (this.service_tier) req.service_tier = this.service_tier;
 
-    return req
+    return req;
   }
 }

--- a/tests/echo-chatbot.test.ts
+++ b/tests/echo-chatbot.test.ts
@@ -1,19 +1,19 @@
-import { test, expect } from "bun:test"
-import { EchoBot } from "../src/colloquy"
+import { test, expect } from "bun:test";
+import { EchoBot } from "../src/colloquy";
 
 test("create a simple echo chatbot", async () => {
-  const bot = new EchoBot()
-  expect(await bot.prompt("hello")).toEqual("hello")
-})
+  const bot = new EchoBot();
+  expect(await bot.prompt("hello")).toEqual("hello");
+});
 
 test("includes history of previous prompts", async () => {
-  const bot = new EchoBot()
-  await bot.prompt("hello")
-  expect(bot.history.map((m) => m.text)).toEqual(["hello", "hello"])
-})
+  const bot = new EchoBot();
+  await bot.prompt("hello");
+  expect(bot.history.map((m) => m.text)).toEqual(["hello", "hello"]);
+});
 
 test("add instructions in constructor", () => {
-  const instructions = "instructions are irrelevant for echoing"
-  const bot = new EchoBot({ instructions })
-  expect(bot.instructions).toEqual(instructions)
-})
+  const instructions = "instructions are irrelevant for echoing";
+  const bot = new EchoBot({ instructions });
+  expect(bot.instructions).toEqual(instructions);
+});

--- a/tests/function.test.ts
+++ b/tests/function.test.ts
@@ -1,41 +1,41 @@
-import { test, expect } from "bun:test"
-import { PromptFunction } from "../src/function"
+import { test, expect } from "bun:test";
+import { PromptFunction } from "../src/function";
 
 test("converts parameters from object", async () => {
-  let input: string = ""
-  const fn = new PromptFunction(function test(a="a") {
-    input = a
-  })
-  await fn.invoke({ a: "b" })
-  expect(input).toEqual("b")
-})
+  let input: string = "";
+  const fn = new PromptFunction(function test(a = "a") {
+    input = a;
+  });
+  await fn.invoke({ a: "b" });
+  expect(input).toEqual("b");
+});
 
 test("provides the return value", async () => {
   const fn = new PromptFunction(function test() {
-    return "test"
-  })
-  expect(await fn.invoke({})).toEqual("test")
-})
+    return "test";
+  });
+  expect(await fn.invoke({})).toEqual("test");
+});
 
 test("provides numeric return values as strings", async () => {
   const fn = new PromptFunction(function test() {
-    return 1
-  })
-  expect(await fn.invoke({})).toEqual("1")
-})
+    return 1;
+  });
+  expect(await fn.invoke({})).toEqual("1");
+});
 
 test("provides object return values as strings", async () => {
   const fn = new PromptFunction(function test() {
-    return { a: 1 }
-  })
-  expect(await fn.invoke({})).toEqual('{"a":1}')
-})
+    return { a: 1 };
+  });
+  expect(await fn.invoke({})).toEqual('{"a":1}');
+});
 
 test("is able to extract parameters of functions with a body containing a comma", async () => {
-  let input: boolean = false
-  const fn = new PromptFunction(function test(a="a") {
-    input = ["a", "b"][1] == a
-  })
-  await fn.invoke({ a: "b" })
-  expect(input).toBeTrue()
-})
+  let input: boolean = false;
+  const fn = new PromptFunction(function test(a = "a") {
+    input = ["a", "b"][1] == a;
+  });
+  await fn.invoke({ a: "b" });
+  expect(input).toBeTrue();
+});

--- a/tests/openai_bot.test.ts
+++ b/tests/openai_bot.test.ts
@@ -1,25 +1,35 @@
-import { describe, test, expect, type Mock } from "bun:test"
-import { OpenAIBot, PromptFunction, UnnamedFunctionError } from "../src/colloquy"
-import type { Response, EasyInputMessage, ResponseFunctionToolCall, ResponseCreateParams, ResponseInput } from "openai/resources/responses/responses.mjs"
-import { FunctionCallMessage, ReasoningMessage } from "../src/openai/message"
-import { parameters_for, type Parameter } from "../src/function"
-import { mock_multiple_return_values, mock_requests } from "./utils"
-import { tool } from "../src/openai/function"
-import { RoleMessage } from "../src/message"
+import { describe, test, expect, type Mock } from "bun:test";
+import {
+  OpenAIBot,
+  PromptFunction,
+  UnnamedFunctionError,
+} from "../src/colloquy";
+import type {
+  Response,
+  EasyInputMessage,
+  ResponseFunctionToolCall,
+  ResponseCreateParams,
+  ResponseInput,
+} from "openai/resources/responses/responses.mjs";
+import { FunctionCallMessage, ReasoningMessage } from "../src/openai/message";
+import { parameters_for, type Parameter } from "../src/function";
+import { mock_multiple_return_values, mock_requests } from "./utils";
+import { tool } from "../src/openai/function";
+import { RoleMessage } from "../src/message";
 
 class MockOpenAIBot extends OpenAIBot {
-  mock!: Mock<any>
+  mock!: Mock<any>;
   constructor(...args: ConstructorParameters<typeof OpenAIBot>) {
-    super(...args)
-    this.mock_response_text("")
+    super(...args);
+    this.mock_response_text("");
   }
 
   get requests(): ResponseCreateParams[] {
-    return mock_requests(this.mock)
+    return mock_requests(this.mock);
   }
 
   mock_response_text(output_text: string) {
-    this.mock_responses([this.text_response(output_text)])
+    this.mock_responses([this.text_response(output_text)]);
   }
 
   text_response(output_text: string): Response {
@@ -39,152 +49,164 @@ class MockOpenAIBot extends OpenAIBot {
       tool_choice: "none",
       tools: [],
       top_p: null,
-      output: [{
-        id: "12345",
-        type: "message",
-        status: "completed",
-        content: [{
-          type: "output_text",
-          annotations: [],
-          text: output_text,
-        }],
-        role: "assistant",
-      }]
-    }
+      output: [
+        {
+          id: "12345",
+          type: "message",
+          status: "completed",
+          content: [
+            {
+              type: "output_text",
+              annotations: [],
+              text: output_text,
+            },
+          ],
+          role: "assistant",
+        },
+      ],
+    };
   }
 
   mock_responses(responses: any[]) {
-    this.mock = mock_multiple_return_values(responses)
-    this.openai.responses.create = this.mock
+    this.mock = mock_multiple_return_values(responses);
+    this.openai.responses.create = this.mock;
   }
 }
 
 test("create a simple openai bot", async () => {
-  const bot = new MockOpenAIBot()
-  const response = "Hi!"
-  bot.mock_response_text(response)
-  expect(await bot.prompt("hello")).toEqual(response)
-})
+  const bot = new MockOpenAIBot();
+  const response = "Hi!";
+  bot.mock_response_text(response);
+  expect(await bot.prompt("hello")).toEqual(response);
+});
 
 test("includes history of previous prompts", async () => {
-  const bot = new MockOpenAIBot()
-  bot.mock_response_text("Hi!")
-  await bot.prompt("hello")
-  expect(bot.history).toEqual([new RoleMessage("user", "hello"), new RoleMessage("assistant", "Hi!")])
-})
+  const bot = new MockOpenAIBot();
+  bot.mock_response_text("Hi!");
+  await bot.prompt("hello");
+  expect(bot.history).toEqual([
+    new RoleMessage("user", "hello"),
+    new RoleMessage("assistant", "Hi!"),
+  ]);
+});
 
 test("sends instructions", async () => {
-  const bot = new MockOpenAIBot({ instructions: "something" })
-  bot.mock_response_text("Hi!")
-  await bot.prompt("hello")
-  expect(bot.requests.at(-1)!.instructions).toEqual("something")
-})
+  const bot = new MockOpenAIBot({ instructions: "something" });
+  bot.mock_response_text("Hi!");
+  await bot.prompt("hello");
+  expect(bot.requests.at(-1)!.instructions).toEqual("something");
+});
 
 test("excludes system message when instructions are absent", async () => {
-  const bot = new MockOpenAIBot()
-  bot.mock_response_text("hi")
-  await bot.prompt("hi")
-  expect((bot.requests.at(-1)!.input as ResponseInput).map(
-    (i) => (i as EasyInputMessage).role
-  )).not.toContain("system")
-})
+  const bot = new MockOpenAIBot();
+  bot.mock_response_text("hi");
+  await bot.prompt("hi");
+  expect(
+    (bot.requests.at(-1)!.input as ResponseInput).map(
+      (i) => (i as EasyInputMessage).role,
+    ),
+  ).not.toContain("system");
+});
 
 test("includes history in subsequent prompts", async () => {
-  const bot = new MockOpenAIBot()
-  bot.mock_response_text("Hello, how are you?")
-  await bot.prompt("Hi!")
-  bot.mock_response_text("That's nice")
-  await bot.prompt("Good")
-  expect((bot.requests.at(-1)!.input as ResponseInput).map(
-    (i) => (i as EasyInputMessage).content
-  )).toEqual([
-    "Hi!",
-    "Hello, how are you?",
-    "Good",
-  ])
-})
+  const bot = new MockOpenAIBot();
+  bot.mock_response_text("Hello, how are you?");
+  await bot.prompt("Hi!");
+  bot.mock_response_text("That's nice");
+  await bot.prompt("Good");
+  expect(
+    (bot.requests.at(-1)!.input as ResponseInput).map(
+      (i) => (i as EasyInputMessage).content,
+    ),
+  ).toEqual(["Hi!", "Hello, how are you?", "Good"]);
+});
 
 describe("functions", () => {
   test("the provided function is provided as a tool", async () => {
     const fn = new PromptFunction(() => {}, {
       name: "test",
-    })
+    });
     const bot = new MockOpenAIBot({
       functions: [fn],
-    })
-    await bot.prompt("test")
-    expect(bot.requests.at(-1)!.tools).toEqual([{
-      type: "function",
-      name: tool(fn).name,
-      parameters: {
-        type: "object",
-        properties: {},
-        additionalProperties: false,
-        required: [],
+    });
+    await bot.prompt("test");
+    expect(bot.requests.at(-1)!.tools).toEqual([
+      {
+        type: "function",
+        name: tool(fn).name,
+        parameters: {
+          type: "object",
+          properties: {},
+          additionalProperties: false,
+          required: [],
+        },
+        strict: true,
       },
-      strict: true,
-    }])
-  })
+    ]);
+  });
 
   test("an unnamed anonymous function throws an error", () => {
-    expect(() => new PromptFunction(() => {})).toThrow(new UnnamedFunctionError())
-    expect(() => new PromptFunction(function () {})).toThrow(UnnamedFunctionError)
-  })
+    expect(() => new PromptFunction(() => {})).toThrow(
+      new UnnamedFunctionError(),
+    );
+    expect(() => new PromptFunction(function () {})).toThrow(
+      UnnamedFunctionError,
+    );
+  });
 
   test("the name of a function is used", () => {
-    const fn = new PromptFunction(function test() {})
-    expect(tool(fn).name).toEqual("test")
-  })
+    const fn = new PromptFunction(function test() {});
+    expect(tool(fn).name).toEqual("test");
+  });
 
   test("a description is included", () => {
     const fn = new PromptFunction(function test() {}, {
       description: "a test function",
-    })
+    });
 
-    expect(tool(fn).description).toEqual("a test function")
-  })
+    expect(tool(fn).description).toEqual("a test function");
+  });
 
   test("a parameter is included", () => {
-    const fn = new PromptFunction(function test(_a: unknown) {})
-    expect(tool(fn).parameters.properties["_a"]).toEqual({ type: "any" })
-  })
+    const fn = new PromptFunction(function test(_a: unknown) {});
+    expect(tool(fn).parameters.properties["_a"]).toEqual({ type: "any" });
+  });
 
   test("excludes spaces when extracting function names", () => {
     expect(parameters_for((_a: any, _b: any) => {})).toEqual([
       ["_a", { type: "any" }],
       ["_b", { type: "any" }],
-    ])
-  })
+    ]);
+  });
 
   test("handles default parameters", () => {
-    expect(parameters_for((_a: any, _b = true, _c = 1) => {}))
-      .toEqual([
-        ["_a", { type: "any" }],
-        ["_b", { type: "boolean" }],
-        ["_c", { type: "number" }],
-      ])
-  })
+    expect(parameters_for((_a: any, _b = true, _c = 1) => {})).toEqual([
+      ["_a", { type: "any" }],
+      ["_b", { type: "boolean" }],
+      ["_c", { type: "number" }],
+    ]);
+  });
 
   test("attaches provided information", () => {
     const fn = new PromptFunction(function test(_a: unknown) {}, {
-      parameters: { "_a": { type: "string" }}
-    })
-    expect(tool(fn).parameters.properties["_a"]).toEqual({ type: "string" })
-  })
+      parameters: { _a: { type: "string" } },
+    });
+    expect(tool(fn).parameters.properties["_a"]).toEqual({ type: "string" });
+  });
 
   test("detects an object correctly", () => {
-    const fn = new PromptFunction(function test(_a = { foo: 1 }) {})
-    const param = tool(fn).parameters.properties["_a"] as Parameter
-    expect(param.type).toEqual("object")
+    const fn = new PromptFunction(function test(_a = { foo: 1 }) {});
+    const param = tool(fn).parameters.properties["_a"] as Parameter;
+    expect(param.type).toEqual("object");
     expect(param.properties).toEqual({
-      foo: { type: "number" }
-    })
-  })
+      foo: { type: "number" },
+    });
+  });
 
   test("detects a nested object correctly", () => {
-    const fn = new PromptFunction(function test(_a = { foo: { bar: 1 } }) {})
-    const param = tool(fn).parameters.properties["_a"] as Parameter
-    expect(param.type).toEqual("object")
+    const fn = new PromptFunction(function test(_a = { foo: { bar: 1 } }) {});
+    const param = tool(fn).parameters.properties["_a"] as Parameter;
+    expect(param.type).toEqual("object");
     expect(param.properties).toEqual({
       foo: {
         type: "object",
@@ -192,80 +214,93 @@ describe("functions", () => {
           bar: { type: "number" },
         },
       },
-    })
-  })
+    });
+  });
 
   test("null parameter", () => {
-    const fn = new PromptFunction(function test(_null = null) {})
-    expect((tool(fn).parameters.properties["_null"] as Parameter).type)
-      .toEqual("null")
-  })
+    const fn = new PromptFunction(function test(_null = null) {});
+    expect((tool(fn).parameters.properties["_null"] as Parameter).type).toEqual(
+      "null",
+    );
+  });
 
   test("provided description is included", () => {
-    const description = "first test parameter"
-    const fn = new PromptFunction(function test(_a = 1) {}, { parameters: {
-      _a: { description }
-    } })
-    const param = tool(fn).parameters.properties["_a"] as Parameter
-    expect(param.description).toEqual(description)
-    expect(param.type).toEqual("number")
-  })
+    const description = "first test parameter";
+    const fn = new PromptFunction(function test(_a = 1) {}, {
+      parameters: {
+        _a: { description },
+      },
+    });
+    const param = tool(fn).parameters.properties["_a"] as Parameter;
+    expect(param.description).toEqual(description);
+    expect(param.type).toEqual("number");
+  });
 
   test("nested parameters are augmented", () => {
-    const description = "first test parameter"
-    const fn = new PromptFunction(function test(_a = {
-      b: { c: 1 }
-    }) {}, { parameters: {
-      _a: {
-        properties: { b: {
-          properties: {
-            c: { description }
-          }
-        } } },
-    } })
+    const description = "first test parameter";
+    const fn = new PromptFunction(
+      function test(
+        _a = {
+          b: { c: 1 },
+        },
+      ) {},
+      {
+        parameters: {
+          _a: {
+            properties: {
+              b: {
+                properties: {
+                  c: { description },
+                },
+              },
+            },
+          },
+        },
+      },
+    );
     const param = (
-      (
-        tool(fn).parameters.properties["_a"] as Parameter
-      ).properties!["b"] as Parameter
-    ).properties!["c"] as Parameter
-    expect(param.description).toEqual(description)
-    expect(param.type).toEqual("number")
-  })
+      (tool(fn).parameters.properties["_a"] as Parameter).properties![
+        "b"
+      ] as Parameter
+    ).properties!["c"] as Parameter;
+    expect(param.description).toEqual(description);
+    expect(param.type).toEqual("number");
+  });
 
   test("commas in nested definitions", () => {
-    const fn = new PromptFunction(function test(_a = { b: 1, c: "foo" }) {})
-    expect(Object.keys(tool(fn).parameters.properties)).toEqual(["_a"])
-  })
+    const fn = new PromptFunction(function test(_a = { b: 1, c: "foo" }) {});
+    expect(Object.keys(tool(fn).parameters.properties)).toEqual(["_a"]);
+  });
 
   test("calls a function when AI requests it", async () => {
-    let called = false
+    let called = false;
     const fn = new PromptFunction(function test() {
-      called = true
-      return "test"
-    })
-    const bot = new MockOpenAIBot({ functions: [fn] })
+      called = true;
+      return "test";
+    });
+    const bot = new MockOpenAIBot({ functions: [fn] });
 
     const function_call_output: ResponseFunctionToolCall = {
       type: "function_call",
       call_id: "12345",
       name: "test",
       arguments: "{}",
-    }
+    };
 
     bot.mock_responses([
       { output: [function_call_output] },
       bot.text_response("Hello"),
-    ])
+    ]);
 
-    await bot.prompt("hi")
-    expect(called).toBeTrue()
+    await bot.prompt("hi");
+    expect(called).toBeTrue();
 
     expect(bot.requests.map((r) => r.input)).toEqual([
       [
         {
           content: "hi",
           role: "user",
-        }
+        },
       ],
       [
         {
@@ -277,46 +312,50 @@ describe("functions", () => {
           type: "function_call_output",
           call_id: function_call_output.call_id,
           output: "test",
-        }
+        },
       ],
-    ])
+    ]);
 
     expect(bot.history).toEqual([
       new RoleMessage("user", "hi"),
       new FunctionCallMessage(fn, function_call_output, "test"),
       new RoleMessage("assistant", "Hello"),
-    ])
-  })
-})
+    ]);
+  });
+});
 
 test("Includes reasoning in history", async () => {
-  const bot = new MockOpenAIBot()
+  const bot = new MockOpenAIBot();
   bot.mock_responses([
     {
       output_text: "Hi",
       status: "completed",
       output: [
         {
-          "id": "id",
-          "type": "reasoning",
-          "summary": [],
+          id: "id",
+          type: "reasoning",
+          summary: [],
         },
         {
           type: "message",
           status: "completed",
-        }
+        },
       ],
-    }
-  ])
-  await bot.prompt("Hi")
-  expect(bot.history).toContainEqual(new ReasoningMessage("id", []))
-})
+    },
+  ]);
+  await bot.prompt("Hi");
+  expect(bot.history).toContainEqual(new ReasoningMessage("id", []));
+});
 
 test("Calls functions even with a completed status", async () => {
-  let called = false
+  let called = false;
   const bot = new MockOpenAIBot({
-    functions: [new PromptFunction(function mark_called() { called = true })],
-  })
+    functions: [
+      new PromptFunction(function mark_called() {
+        called = true;
+      }),
+    ],
+  });
   bot.mock_responses([
     {
       output_text: "Hi",
@@ -333,24 +372,35 @@ test("Calls functions even with a completed status", async () => {
           call_id: "id",
         },
       ],
-    }
-  ])
-  await bot.prompt("Hi")
-  expect(called).toBeTrue()
-})
+    },
+  ]);
+  await bot.prompt("Hi");
+  expect(called).toBeTrue();
+});
 
 test("Provides a reply, even when the status is completed, if there is nothing but function calls in the output", () => {
-  const bot = new MockOpenAIBot()
-  expect(bot.needs_reply({
-    status: "completed",
-    output: [{ type: "function_call" }],
-  } as Response)).toBeTrue()
-})
+  const bot = new MockOpenAIBot();
+  expect(
+    bot.needs_reply({
+      status: "completed",
+      output: [{ type: "function_call" }],
+    } as Response),
+  ).toBeTrue();
+});
 
 test("Retains any history provided in the constructor", async () => {
-  const bot = new MockOpenAIBot({ history: [new RoleMessage("user", "Hi"), new RoleMessage("assistant", "Hello")] })
-  bot.mock_response_text("Howdy")
-  await bot.prompt("Yo")
-  expect(bot.history.map((m) => (m as RoleMessage<any, any>).text))
-    .toEqual(["Hi", "Hello", "Yo", "Howdy"])
-})
+  const bot = new MockOpenAIBot({
+    history: [
+      new RoleMessage("user", "Hi"),
+      new RoleMessage("assistant", "Hello"),
+    ],
+  });
+  bot.mock_response_text("Howdy");
+  await bot.prompt("Yo");
+  expect(bot.history.map((m) => (m as RoleMessage<any, any>).text)).toEqual([
+    "Hi",
+    "Hello",
+    "Yo",
+    "Howdy",
+  ]);
+});

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,12 +1,12 @@
-import { mock, type Mock } from "bun:test"
+import { mock, type Mock } from "bun:test";
 
 export function mock_multiple_return_values<T>(values: T[]): Mock<any> {
   return mock(async () => {
-      if (values.length == 0) throw new Error("expected a mocked value")
-      return values.shift() as T
-  })
+    if (values.length == 0) throw new Error("expected a mocked value");
+    return values.shift() as T;
+  });
 }
 
 export function mock_requests(m: Mock<any>) {
-  return m.mock.calls.map((c: any[]) => c[0])
+  return m.mock.calls.map((c: any[]) => c[0]);
 }


### PR DESCRIPTION
- Upgraded openai package from ^4.95.0 to 4.104.0
- Fixed TypeScript error in openai_bot.ts where status property was accessed on union type
- Added type guard to check output.type === "message" before accessing status property
- Bumped version to 0.8.0 to reflect breaking changes
- Applied prettier formatting across codebase

🤖 Generated with [Claude Code](https://claude.ai/code)